### PR TITLE
#12 ft(delete): activate delete btn to display warning

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -200,6 +200,7 @@
                     </div>
                 </div>
             </div>
+            <div class="warn-container"></div>
             <div class="dashboard-content">
                 <h2>Analysis</h2>
                 <div class="cards-container">

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -36,6 +36,7 @@ function showDashBoard() {
   if(articlesList.classList.contains('show')) {
     articlesList.classList.remove('show')
   }
+  warnContiner.style.display = 'none';
   dashBoardContent.classList.toggle('toggle-visibility')
 }
 
@@ -56,6 +57,7 @@ function showUserProfile() {
   }
   profilePopup.classList.toggle('display')
   editForm.style.display = 'none';
+  warnContiner.style.display = 'none';
 }
 
 function logOutfn() {
@@ -72,12 +74,15 @@ function editProfile() {
 function addArticle() {
   clearBoard()
   addArticleForm.style.display = 'flex';
+  warnContiner.style.display = 'none';
 }
 
 function viewAllArticles() {
   clearBoard()
   articlesList.classList.toggle('show')
   editForm.style.display = 'none';
+  addArticleForm.style.display = 'none';
+
 }
 
 function clearBoard() {
@@ -87,4 +92,30 @@ function clearBoard() {
   if(profilePopup.classList.contains('display')){
     profilePopup.classList.toggle('display')
   }
+}
+
+/*...........
+warning 
+*/
+
+const deleteBtn = document.querySelectorAll('.fa-trash-alt');
+const warnContiner = document.querySelector('.warn-container');
+
+deleteBtn.forEach(btn => btn.addEventListener('click', deleteArticle));
+
+function deleteArticle() {
+  if(articlesList.classList.contains('show')) {
+    articlesList.classList.remove('show')
+  }
+  warnContiner.style.display = 'flex';
+   warnContiner.innerHTML =
+  `<div class="warn">
+      <i class="fas fa-exclamation-triangle"></i>
+      <p>Be aware that the action you are going to take is irreversible once it’s done.</p>
+      <div id="cfrm-btn">
+        <button id="cancel">Cancel</button>
+        <button id="confirm">Delete</button>
+      </div>
+   </div>
+  `;
 }

--- a/styles/admin.css
+++ b/styles/admin.css
@@ -547,6 +547,77 @@ styles for article list
 .fa-info-circle:hover{
     cursor: pointer;
 }
+
+/*.......................
+warning card
+*/
+
+.warn-container{
+    display: flex;
+    flex-direction: column;
+    -ms-flex-direction: column;
+    width: 680px;
+    height: 550px;
+    margin-top: 10%;
+    align-self: center;
+    border-radius: 15px;
+    padding: 20px 40px;
+    display: none;
+}
+.warn{
+    display: flex;
+    flex-direction:column;
+    -ms-flex-direction: column;
+    justify-content: space-between;
+    background: #D0546D;
+    width: 680px;
+    height: 300px;
+    align-self: center;
+    padding: 10px 30px;
+    border-radius: 15px;
+}
+.fa-exclamation-triangle{
+    color:#243447;
+    align-self: center;
+    font-size: 40px;
+}
+.warn p{
+    color: #FAF4F4;
+    font-family: 'ROBOTO', sans-serif;
+    font-size: 20px;
+    padding: 10px 20px
+}
+#cfrm-btn{
+    display:flex;
+    flex-direction: row;
+    -ms-flex-direction: row;
+    justify-content: space-between;
+    padding-bottom: 30px;
+}
+#cfrm-btn button:hover{
+    cursor: pointer;
+}
+#cfrm-btn button:focus{
+    outline: none;
+}
+#cancel,
+#confirm{
+    background: #243447;
+    margin-top: auto;
+    height: 40px;
+    width: 150px;
+    color: #FAF4F4;
+    font-family: 'ROBOTO', sans-serif;
+    font-size: 20px;
+    border: none;
+    border-radius: 5px;
+}
+#confirm:visited,
+#confirm:focus,
+#confirm:hover{
+    color:#D0546D ;
+}
+
 /*.......................
 styles of the dashboard access
 */


### PR DESCRIPTION
#### What does this PR do?

- Enable blog owner to delete an existing blog

#### Description of Task to be completed?

- Make a warning card

- Add scripts to display the warning card by activating the delete button

#### How should this be manually tested?

- login in to get redirected to the dashboard

- Once you logged in  you click on **`Posts`** you will be able to see the list of all posts

- On the list the post will come with the **`delete button`** and you click on it

- Then it will trigger a warning form and you have option to **`cancel`** or **`delete`**


#### Any background context you want to provide?

- To delete article it must be your own article

#### What are the relevant Trello stories?

- [#12](https://trello.com/c/IAZXBkoS/12-delete-article)

#### Screenshots (if appropriate)

![delete-warning-screenshoot](https://user-images.githubusercontent.com/54619678/93973952-5fe3ff80-fd75-11ea-90b1-1cb6eb55d29b.png)


#### Questions:

- N/A