### PR TITLE
#27 ft(nav): add scripts to make navigation bar responsive

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -26,6 +26,7 @@
                 <li><a href="../login/index.html">Login</a></li>
             </ul>
         </nav>
+        <span class="fas span"><i class="fas fa-bars"></i></span>
     </header>
     <div class="toggle-switch">
         <button><i class="fas fa-moon"></i></button>
@@ -192,6 +193,7 @@
             </div>
         </div>
     </footer>
+    <script src="../scripts/helper.js"></script>
 </body>
 
 </html>

--- a/blog/article.html
+++ b/blog/article.html
@@ -26,6 +26,7 @@
                 <li><a href="../login/index.html">Login</a></li>
             </ul>
         </nav>
+        <span class="fas span"><i class="fas fa-bars"></i></span>
     </header>
     <div class="toggle-switch">
         <button><i class="fas fa-moon"></i></button>
@@ -166,6 +167,7 @@
         </div>
     </footer>
     <script src="../scripts/article.js"></script>
+    <script src="../scripts/helper.js"></script>
 </body>
 
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -26,6 +26,7 @@
                 <li><a href="../login/index.html">Login</a></li>
             </ul>
         </nav>
+        <span class="fas span"><i class="fas fa-bars"></i></span>
     </header>
     <div class="toggle-switch">
         <button><i class="fas fa-moon"></i></button>
@@ -332,6 +333,7 @@
         </div>
     </footer>
     <script src="../scripts/blog.js"></script>
+    <script src="../scripts/helper.js"></script>
 </body>
 
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -26,6 +26,7 @@
                 <li><a href="../login/index.html">Login</a></li>
             </ul>
         </nav>
+        <span class="fas span"><i class="fas fa-bars"></i></span>
     </header>
     <div class="toggle-switch">
         <button><i class="fas fa-moon"></i></button>
@@ -88,6 +89,7 @@
         </div>
     </footer>
     <script src="../scripts/contact.js"></script>
+    <script src="../scripts/helper.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
                 <li><a href="./login/index.html">Login</a></li>
             </ul>
         </nav>
+        <span class="fas span"><i class="fas fa-bars"></i></span>
     </header>
     <div class="toggle-switch">
         <button><i class="fas fa-moon"></i></button>
@@ -99,6 +100,7 @@
         </div>
     </footer>
     <script src="./scripts/index.js"></script>
+    <script src="./scripts/helper.js"></script>
 </body>
 
 </html>

--- a/login/index.html
+++ b/login/index.html
@@ -26,6 +26,7 @@
                 <li id="current-nav"><a href="#">Login</a></li>
             </ul>
         </nav>
+        <span class="fas span"><i class="fas fa-bars"></i></span>
     </header>
     <div class="toggle-switch">
         <button><i class="fas fa-moon"></i></button>
@@ -90,6 +91,7 @@
         </div>
     </footer>
     <script src="../scripts/login.js"></script>
+    <script src="../scripts/helper.js"></script>
 </body>
 
 </html>

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -1,0 +1,22 @@
+const hambergIcon = document.querySelector('fa-bars');
+const menu = document.querySelector('nav');
+const spanIcon = document.querySelector('.span');
+
+
+spanIcon.addEventListener('click', () => {
+    hambergIconDisplay = !hambergIconDisplay;
+    showNav()
+})
+
+let hambergIconDisplay = false;
+function showNav() {
+    if(hambergIconDisplay){
+        menu.classList.add('dropdown');
+        menu.style.display = 'block';
+        spanIcon.innerHTML = `<i class="fas fa-times"></i>`;
+    }else{
+        menu.classList.remove('dropdown');
+        menu.style.display = 'none';
+        spanIcon.innerHTML = `<i class="fas fa-bars"></i>`;
+    }
+}

--- a/signup/index.html
+++ b/signup/index.html
@@ -26,6 +26,7 @@
                 <li><a href="../login/index.html">Login</a></li>
             </ul>
         </nav>
+        <span class="fas span"><i class="fas fa-bars"></i></span>
     </header>
     <div class="toggle-switch">
         <button><i class="fas fa-moon"></i></button>
@@ -99,6 +100,7 @@
         </div>
     </footer>
     <script src="../scripts/signup.js"></script>
+    <script src="../scripts/helper.js"></script>
 </body>
 
 </html>

--- a/styles/helper.css
+++ b/styles/helper.css
@@ -197,11 +197,65 @@ footer{
     padding-bottom: 20px;
 }
 
-
 /*.............
 customize responsiveness
 */
-@media screen and (max-width: 671px){
+@media screen and (min-width: 671px){
+    .span{
+        display: none;
+    }
+    .navbar{
+        display: flex;
+    }
+}
+@media screen and (max-width: 670px){
+    .navbar{
+        display: none;
+    }
+    .dropdown{
+        position: fixed;
+        background-color: rgba(51, 51, 51, 0.63);
+        height: 320px;
+        width: 100%;
+        margin-top: 80px;
+        margin-left: 0;
+        margin-right: 0;
+        transition: transform .5 ease-in-out;
+        -webkit-transtion: -webkit-transform .5 ease-in-out;
+    }
+    .dropdown ul{
+        line-height: 30px;
+        display:block;
+        list-style: none;
+        color: #FAF4F4;
+    }
+    .dropdown ul > li + li {
+        margin-left: 0;
+        border-top: 1px solid #27447E;
+    }
+    .dropdown a{
+        text-decoration: none;
+        margin-left: 30px;
+        line-height: 26px;
+    }
+    .dropdown #current-nav > a{
+        box-shadow: 0 0;
+        text-align: left;
+        color:#28B9AF;
+    }    
+    .span,
+    .fa-bars,
+    .fa-times{
+        align-self: center;
+        margin-right: 10px;
+        font-size: 30px;
+        font-weight: bold;
+        color: #FAF4F4;
+    }
+    .fa-bars:hover,
+    .fa-times:hover{
+        cursor: pointer;
+    }
     #float-container{
         flex-direction: column;
         -ms-flex-direction: column;


### PR DESCRIPTION
#### What does this PR do?

- Customise navigation bar responsiveness

#### Description of Task to be completed?

- Hide navigation links on small size screen

- Display a hamburg icon

- Add functionality to hamburg icon to display navigation links


#### How should this be manually tested?

- To the page and resize the page you should see she navigation links disappear and hamburg icon display

- Click on hamburg icon you will see the navigation links display **`block`**

#### Any background context you want to provide?

- N/A

#### What are the relevant Trello stories?

- [#27](https://trello.com/c/GJtsN06l/27-customise-nav-responsiveness)

#### Screenshots (if appropriate)


![hamberg-nav-screenshoot](https://user-images.githubusercontent.com/54619678/94096809-531ee480-fe25-11ea-9c9f-331b56dc2925.png)



#### Questions:

- N/A